### PR TITLE
fix: Issues with Datum when value equals 0

### DIFF
--- a/src/charts/bar.ts
+++ b/src/charts/bar.ts
@@ -3,7 +3,12 @@ import { Datum, Group } from "../components";
 import { BAR, getPathData } from "../coords";
 import { BarChartSubtype, MaxValue } from "../types";
 import { FONT_SIZE, getTextColor } from "../utils";
-import { getGroupLabelStrokeWidth, getRotate, TEXT_MARGIN } from "./utils";
+import {
+  getGroupLabelStrokeWidth,
+  getRotate,
+  STROKE_WIDTH,
+  TEXT_MARGIN,
+} from "./utils";
 
 const PADDING_X0 = 0.1;
 const PADDING_X1 = 0.05;
@@ -110,6 +115,7 @@ export const getBarGetters = (
           const x = s(0, datumX + (x1bw - x0bw) * 0.5);
           const y = s(0, (datumY - height) * 0.5 - currentAccHeight);
           const rotate = getRotate(_g?.rotate);
+          const strokeWidth = s(0, value ? STROKE_WIDTH : 0);
           const labelX = isGrouped
             ? 0
             : s(
@@ -146,8 +152,9 @@ export const getBarGetters = (
             clipPath,
             x,
             y,
-            fill: datumFill,
             rotate,
+            fill: datumFill,
+            strokeWidth,
             labelX,
             labelY,
             labelFontSize,

--- a/src/charts/bubble.ts
+++ b/src/charts/bubble.ts
@@ -4,7 +4,12 @@ import { BUBBLE, getPathData } from "../coords";
 import { InputGroup } from "../types";
 import { FONT_SIZE, getTextColor } from "../utils";
 import { HierarchyRoot } from "./types";
-import { getGroupLabelStrokeWidth, getRotate, PADDING } from "./utils";
+import {
+  getGroupLabelStrokeWidth,
+  getRotate,
+  PADDING,
+  STROKE_WIDTH,
+} from "./utils";
 
 export const getBubbleGetters = ({
   groups,
@@ -89,6 +94,7 @@ export const getBubbleGetters = ({
           const x = s(0, group.x - datum.x);
           const y = s(0, group.y - datum.y);
           const rotate = getRotate(_g?.rotate, cartoonize);
+          const strokeWidth = s(0, value ? STROKE_WIDTH : 0);
           const labelX = 0;
           const labelY =
             textDims.datumLabel.yShift -
@@ -113,8 +119,9 @@ export const getBubbleGetters = ({
             clipPath,
             x,
             y,
-            fill: datumFill,
             rotate,
+            fill: datumFill,
+            strokeWidth,
             labelX,
             labelY,
             labelFontSize,

--- a/src/charts/pie.ts
+++ b/src/charts/pie.ts
@@ -67,7 +67,9 @@ export const getPieGetters = ({
 
     data.map((datum, i) => {
       const { key, value, fill } = datum.data.data;
-      const angleExtent = datum.endAngle - datum.startAngle;
+      // Angle extent can't be 0, as otherwise NaNs will be introduced
+      // in the path, which will break label clipping.
+      const angleExtent = datum.endAngle - datum.startAngle || 0.001;
       let rotate = (angleExtent - Math.PI) * 0.5;
       const _datum = data?.[i - 1];
 

--- a/src/charts/pie.ts
+++ b/src/charts/pie.ts
@@ -5,7 +5,7 @@ import { BUBBLE, getPathData } from "../coords";
 import { InputDatum, InputGroup } from "../types";
 import { FONT_SIZE, getTextColor, radiansToDegrees } from "../utils";
 import { HierarchyRoot } from "./types";
-import { getGroupLabelStrokeWidth, PADDING } from "./utils";
+import { getGroupLabelStrokeWidth, PADDING, STROKE_WIDTH } from "./utils";
 
 export const getPieGetters = ({
   groups,
@@ -111,6 +111,7 @@ export const getPieGetters = ({
           const clipPath = d;
           const x = s(0, datumX - (singlePie ? group.r * 0.5 : 0));
           const y = s(0, datumY);
+          const strokeWidth = s(0, value ? STROKE_WIDTH : 0);
           const labelX = s(
             x,
             -x + group.r * 0.5 * Math.sin(rotate + Math.PI * 0.5)
@@ -139,7 +140,12 @@ export const getPieGetters = ({
             clipPath,
             x,
             y,
+            rotate:
+              rotateDegrees - (_g?.rotate ?? 0) >= 180
+                ? rotateDegrees - 360
+                : rotateDegrees,
             fill: datumFill,
+            strokeWidth,
             labelX,
             labelY,
             labelFontSize,
@@ -147,10 +153,6 @@ export const getPieGetters = ({
             valueX,
             valueY,
             valueFontSize,
-            rotate:
-              rotateDegrees - (_g?.rotate ?? 0) >= 180
-                ? rotateDegrees - 360
-                : rotateDegrees,
             valueFill,
             opacity,
           };

--- a/src/charts/treemap.ts
+++ b/src/charts/treemap.ts
@@ -4,7 +4,12 @@ import { BAR, getPathData } from "../coords";
 import { InputGroup } from "../types";
 import { FONT_SIZE, getTextColor } from "../utils";
 import { TreemapHierarchyRoot } from "./types";
-import { getGroupLabelStrokeWidth, getRotate, TEXT_MARGIN } from "./utils";
+import {
+  getGroupLabelStrokeWidth,
+  getRotate,
+  STROKE_WIDTH,
+  TEXT_MARGIN,
+} from "./utils";
 
 const PADDING = 2;
 
@@ -94,6 +99,7 @@ export const getTreemapGetters = ({
           const x = s(0, datum.x0 - group.x0 - (groupWidth - dWidth) * 0.5);
           const y = s(0, datum.y0 - group.y0 - (groupHeight - dHeight) * 0.5);
           const rotate = getRotate(_g?.rotate);
+          const strokeWidth = s(0, value ? STROKE_WIDTH : 0);
           const labelWidth = svg.measureText(key, "datumLabel").width;
           const labelX = s(0, (labelWidth - dWidth) * 0.5 + TEXT_MARGIN);
           const labelY = s(0, -(dHeight * 0.5 + textDims.datumLabel.yShift));
@@ -112,8 +118,9 @@ export const getTreemapGetters = ({
             clipPath,
             x,
             y,
-            fill: datumFill,
             rotate,
+            fill: datumFill,
+            strokeWidth,
             labelX,
             labelY,
             labelFontSize,

--- a/src/charts/utils.ts
+++ b/src/charts/utils.ts
@@ -5,6 +5,8 @@ export const TEXT_MARGIN = 8;
 
 export const PADDING = 4;
 
+export const STROKE_WIDTH = 2;
+
 export const getRotate = (_rotate = 0, cartoonize?: boolean): number => {
   const rotate = _rotate <= -90 ? -180 : _rotate <= 90 ? 0 : 180;
 

--- a/src/components/Datum.module.scss
+++ b/src/components/Datum.module.scss
@@ -4,7 +4,6 @@
     .path {
       will-change: d;
       stroke: white;
-      stroke-width: 2;
     }
     .clipPath {
       will-change: d;

--- a/src/components/Datum.ts
+++ b/src/components/Datum.ts
@@ -11,8 +11,9 @@ type G = {
   clipPath: string;
   x: number;
   y: number;
-  fill: string;
   rotate: number;
+  fill: string;
+  strokeWidth: number;
   labelX: number;
   labelY: number;
   labelFontSize: number;
@@ -106,6 +107,7 @@ export const render = ({
     .join("path")
     .attr("class", style.path)
     .attr("d", (d) => d.d)
+    .style("stroke-width", (d) => d.strokeWidth)
     .style("fill", (d) => d.fill);
 
   const clipPathSelection = dataSelection


### PR DESCRIPTION
- `stroke-width` is no longer always equal to 2, but rather depends on whether value is greater than 0
- path's `d` for Pie chart is no longer broken when value equals 0