### PR TITLE
fix: Do not set paddingInner to 0 for single datum steps (Bar)

### DIFF
--- a/src/charts/bar.ts
+++ b/src/charts/bar.ts
@@ -202,7 +202,7 @@ const getScales = ({
   const x0Scale = scaleBand()
     .domain(groupsKeys)
     .range([0, width])
-    .paddingInner(singleGroup || dataKeys.length === 1 ? 0 : PADDING_X0);
+    .paddingInner(singleGroup ? 0 : PADDING_X0);
   const x0bw = x0Scale.bandwidth();
   const yScale = scaleLinear()
     .domain([0, maxValue.actual])


### PR DESCRIPTION
Padding between groups is no longer removed when there is only one datum passed to a step.