### PR TITLE
feat: Add Scatter chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Limitless animations and a powerful mechanism to control them combined with a co
 
 ```ts
 const div = document.querySelector("#story");
-const groups: Group[] = [
+const groups = [
   {
     key: "Alice",
     data: [
@@ -146,7 +146,7 @@ const baseStep = {
   showDatumLabels: true,
   groups,
 };
-const steps: Step[] = [
+const steps = [
   {
     key: "zero",
     chartType: "treemap",
@@ -193,14 +193,13 @@ https://user-images.githubusercontent.com/52032047/221407756-3038fae9-84ed-4d77-
 
 ### ⚙️ Step configuration
 
+Step configurations vary by chart type, but there's a common part that's shared.
+
 ```ts
 type Step = {
   // Unique identifier of a step.
   // Passed as a first argument to the `render` method.
   key: string;
-  chartType: "bar" | "bubble" | "pie" | "treemap";
-  // Only applicable for bar chart.
-  chartSubtype?: "grouped" | "stacked";
   title?: string;
   titleAnchor?: "start" | "middle" | "end";
   subtitle?: string;
@@ -211,40 +210,105 @@ type Step = {
   legendTitle?: string;
   legendAnchor?: "start" | "middle" | "end";
   showValues?: boolean;
-  // Artificial maximum value.
-  // Useful for fixing the value scale domain to show evolution of values.
-  maxValue?: number;
   showDatumLabels?: boolean;
-  // Only applicable for bar chart.
-  verticalAxis?: {
-    show?: boolean;
-    title?: string;
-  };
   palette?: "default" | "pastel" | "vivid" | "oranges";
   // If true, enables hand-drawn look.
   cartoonize?: boolean;
-  // Data used to render a chart.
-  groups: Array<{
-    // Unique identifier of a group.
-    // Will be used to match and animate the groups between consecutive steps.
-    key: string;
-    opacity?: number;
-    data: Array<{
-      // Unique identifier of a datum.
-      // Will be used to match and animate the data inside a given group between
-      // consecutive steps.
-      key: string;
-      value: number;
-      // Use when you want to move a given datum across groups.
-      // Should be defined as "groupKey:datumKey" for a datum from an exiting
-      // group you want to "teleport" it from.
-      teleportFrom?: string;
-      // HEX, e.g. "#CCCCCC"
-      fill?: string;
-      opacity?: number;
-    }>;
-  }>;
-};
+} & (
+  | {
+      chartType: "bar";
+      chartSubtype?: "grouped" | "stacked";
+      valueScale?: {
+        // Useful for fixing the value scale domain to show evolution of values.
+        maxValue?: number;
+      };
+      verticalAxis?: {
+        show?: boolean;
+        title?: string;
+      };
+      groups: Array<{
+        // Unique identifier of a group.
+        // Used to match and animate the groups between consecutive steps.
+        key: string;
+        opacity?: number;
+        data: Array<{
+          // Unique identifier of a datum.
+          // Used to match and animate the data inside a given group between
+          // consecutive steps.
+          key: string;
+          value: number;
+          // Used to teleport datum between groups. Formatted as "groupKey:datumKey".
+          teleportFrom?: string;
+          // HEX, e.g. "#CCCCCC"
+          fill?: string;
+          opacity?: number;
+        }>;
+      }>;
+    }
+  | {
+      chartType: "bubble" | "pie" | "treemap";
+      valueScale?: {
+        // Useful for fixing the value scale domain to show evolution of values.
+        maxValue?: number;
+      };
+      groups: Array<{
+        // Unique identifier of a group.
+        // Used to match and animate the groups between consecutive steps.
+        key: string;
+        opacity?: number;
+        data: Array<{
+          // Unique identifier of a datum.
+          // Used to match and animate the data inside a given group between
+          // consecutive steps.
+          key: string;
+          value: number;
+          // Used to teleport datum between groups. Formatted as "groupKey:datumKey".
+          teleportFrom?: string;
+          // HEX, e.g. "#CCCCCC"
+          fill?: string;
+          opacity?: number;
+        }>;
+      }>;
+    }
+  | {
+      chartType: "scatter";
+      xScale?: {
+        // Useful for fixing the x scale domain to show evolution of values.
+        maxValue?: number;
+      };
+      yScale?: {
+        // Useful for fixing the y scale domain to show evolution of values.
+        maxValue?: number;
+      };
+      horizontalAxis?: {
+        show?: boolean;
+        title?: string;
+      };
+      verticalAxis?: {
+        show?: boolean;
+        title?: string;
+      };
+      groups: Array<{
+        // Unique identifier of a group.
+        // Used to match and animate the groups between consecutive steps.
+        key: string;
+        opacity?: number;
+        data: Array<{
+          // Unique identifier of a datum.
+          // Used to match and animate the data inside a given group between
+          // consecutive steps.
+          key: string;
+          x: number;
+          y: number;
+          // Used to teleport datum between groups. Formatted as "groupKey:datumKey".
+          teleportFrom?: string;
+          // HEX, e.g. "#CCCCCC"
+          fill?: string;
+          opacity?: number;
+        }>;
+      }>;
+    }
+);
 ```
 
 ### 🔠 Every group is a chart
@@ -344,7 +408,7 @@ const groups = [
 
 You can structure your `Steps` to be based on either more groups (as with the bar chart) or fewer groups (other charts). The main difference between them is that, by default, the color domain is shared at the `Datum` level for bar and pie charts and at the `Group` level for other charts.
 
-This decision comes from the experience that bar charts usually share the same domain within groups (so, _A_ in one group should have the same color as _A_ in all other groups). Pie charts, well, usually do not share the same color within the group, as you would end up with monochromatic slices. Bubble and treemap charts, on the other hand, usually have different "children" within groups. However, you can freely change this behavior by manually setting `shareDomain` to suit your needs, e.g. if you'd like to have a three-group bar chart with colors based on `Group` rather than `Datum`.
+This decision comes from the experience that bar charts usually share the same domain within groups (so, _A_ in one group should have the same color as _A_ in all other groups). Pie charts, well, usually do not share the same color within the group, as you would end up with monochromatic slices. Bubble, scatter and treemap charts, on the other hand, usually have different "children" within groups. However, you can freely change this behavior by manually setting `shareDomain` to suit your needs, e.g. if you'd like to have a three-group bar chart with colors based on `Group` rather than `Datum`.
 
 While this design gives you a lot of freedom to manipulate the elements, it can also pose a problem if you want to make some specific animations.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotteus",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "🦋 Plotteus is a JavaScript data visualization library designed to help you tell better stories.",
   "homepage": "https://plotteus.dev",
   "repository": "github:bprusinowski/plotteus",

--- a/src/charts/bar.ts
+++ b/src/charts/bar.ts
@@ -28,7 +28,7 @@ export const getBarGetters = (
     textDims,
     colorMap,
     cartoonize,
-  }: Group.GetterProps
+  }: Group.GetterPropsValue
 ): Group.Getter[] => {
   const isGrouped = subtype === "grouped";
   const { x0Scale, x0bw, x1Scale, x1bw, yScale } = getScales({

--- a/src/charts/bar.ts
+++ b/src/charts/bar.ts
@@ -105,6 +105,7 @@ export const getBarGetters = (
 
       const datumGetters: Datum.Getter = {
         key,
+        type: "value",
         teleportKey: `${group.key}:${key}`,
         teleportFrom: datum.teleportFrom,
         value,

--- a/src/charts/bar.ts
+++ b/src/charts/bar.ts
@@ -1,7 +1,7 @@
 import { ScaleBand, scaleBand, ScaleLinear, scaleLinear } from "d3-scale";
 import { Datum, Group } from "../components";
 import { BAR, getPathData } from "../coords";
-import { BarChartSubtype, MaxValue } from "../types";
+import { BarChartSubtype, Max } from "../types";
 import { FONT_SIZE, getTextColor } from "../utils";
 import {
   getGroupLabelStrokeWidth,
@@ -20,7 +20,7 @@ export const getBarGetters = (
     groupsKeys,
     dataKeys,
     shareDomain,
-    maxValue,
+    maxValue: { value: maxValue },
     showValues,
     showDatumLabels,
     svg,
@@ -189,7 +189,7 @@ const getScales = ({
   isGrouped: boolean;
   groupsKeys: string[];
   dataKeys: string[];
-  maxValue: MaxValue;
+  maxValue: Max;
   width: number;
   height: number;
 }): {

--- a/src/charts/bubble.ts
+++ b/src/charts/bubble.ts
@@ -78,6 +78,7 @@ export const getBubbleGetters = ({
       const datumFill = fill ?? colorMap.get(key, group.data.key, shareDomain);
       const datumGetters: Datum.Getter = {
         key,
+        type: "value",
         teleportKey: `${group.data.key}:${key}`,
         teleportFrom: datum.data.teleportFrom,
         value,

--- a/src/charts/bubble.ts
+++ b/src/charts/bubble.ts
@@ -1,7 +1,7 @@
 import { hierarchy, pack } from "d3-hierarchy";
 import { Datum, Group } from "../components";
 import { BUBBLE, getPathData } from "../coords";
-import { InputGroup } from "../types";
+import { InputGroupValue } from "../types";
 import { FONT_SIZE, getTextColor } from "../utils";
 import { HierarchyRoot } from "./types";
 import {
@@ -21,7 +21,7 @@ export const getBubbleGetters = ({
   textDims,
   colorMap,
   cartoonize,
-}: Group.GetterProps): Group.Getter[] => {
+}: Group.GetterPropsValue): Group.Getter[] => {
   const root = getRoot({ groups, size: maxValue.k * size });
   const groupsGetters: Group.Getter[] = [];
   // If a custom maxValue was provided, we need to shift the bubbles to the center.
@@ -148,7 +148,7 @@ const getRoot = ({
   groups,
   size,
 }: {
-  groups: InputGroup[];
+  groups: InputGroupValue[];
   size: number;
 }): HierarchyRoot => {
   const root = hierarchy({

--- a/src/charts/bubble.ts
+++ b/src/charts/bubble.ts
@@ -14,7 +14,7 @@ import {
 export const getBubbleGetters = ({
   groups,
   shareDomain,
-  maxValue,
+  maxValue: { value: maxValue },
   showValues,
   showDatumLabels,
   dims: { width, height, size, margin },

--- a/src/charts/pie.ts
+++ b/src/charts/pie.ts
@@ -2,7 +2,7 @@ import { hierarchy, pack } from "d3-hierarchy";
 import { pie, PieArcDatum } from "d3-shape";
 import { Datum, Group } from "../components";
 import { BUBBLE, getPathData } from "../coords";
-import { InputDatum, InputGroup } from "../types";
+import { InputDatumValue, InputGroupValue } from "../types";
 import { FONT_SIZE, getTextColor, radiansToDegrees } from "../utils";
 import { HierarchyRoot } from "./types";
 import { getGroupLabelStrokeWidth, PADDING, STROKE_WIDTH } from "./utils";
@@ -17,7 +17,7 @@ export const getPieGetters = ({
   textDims,
   colorMap,
   cartoonize,
-}: Group.GetterProps): Group.Getter[] => {
+}: Group.GetterPropsValue): Group.Getter[] => {
   const root = getRoot({ groups, size: maxValue.k * size });
   const groupsGetters: Group.Getter[] = [];
   const maxValueShift = maxValue.kc * size * 0.5;
@@ -63,7 +63,7 @@ export const getPieGetters = ({
 
     const data = pie().value((d: any) => d.value)(
       group.children || ([] as any)
-    ) as unknown as PieArcDatum<{ data: InputDatum }>[];
+    ) as unknown as PieArcDatum<{ data: InputDatumValue }>[];
 
     data.map((datum, i) => {
       const { key, value, fill } = datum.data.data;
@@ -172,7 +172,7 @@ const getRoot = ({
   groups,
   size,
 }: {
-  groups: InputGroup[];
+  groups: InputGroupValue[];
   size: number;
 }): HierarchyRoot => {
   const root = hierarchy({

--- a/src/charts/pie.ts
+++ b/src/charts/pie.ts
@@ -10,7 +10,7 @@ import { getGroupLabelStrokeWidth, PADDING, STROKE_WIDTH } from "./utils";
 export const getPieGetters = ({
   groups,
   shareDomain,
-  maxValue,
+  maxValue: { value: maxValue },
   showValues,
   showDatumLabels,
   dims: { width, height, size, margin },

--- a/src/charts/pie.ts
+++ b/src/charts/pie.ts
@@ -88,6 +88,7 @@ export const getPieGetters = ({
 
       const datumGetters: Datum.Getter = {
         key,
+        type: "value",
         teleportKey: `${group.data.key}:${key}`,
         teleportFrom: datum.data.data.teleportFrom,
         value,

--- a/src/charts/scatter.ts
+++ b/src/charts/scatter.ts
@@ -12,7 +12,6 @@ export const getScatterGetters = ({
   cartoonize,
   colorMap,
   showDatumLabels,
-  textDims,
   dims: { width, height, margin, BASE_MARGIN },
 }: Group.GetterPropsXY) => {
   const { xScale, yScale } = getScales({ maxValue, width, height });
@@ -48,7 +47,6 @@ export const getScatterGetters = ({
 
     for (const datum of group.data) {
       const { key, x, y, fill } = datum;
-      const value = 0;
 
       const datumX = xScale(x);
       const datumY = yScale(y);
@@ -56,9 +54,11 @@ export const getScatterGetters = ({
 
       const datumGetters: Datum.Getter = {
         key,
+        type: "xy",
+        xValue: x,
+        yValue: y,
         teleportKey: `${group.key}:${key}`,
         teleportFrom: datum.teleportFrom,
-        value,
         g: ({ s, _g }) => {
           const d = s(
             BAR,

--- a/src/charts/scatter.ts
+++ b/src/charts/scatter.ts
@@ -1,0 +1,3 @@
+import { Group } from "../components";
+
+export const getScatterGetters = (props: Group.GetterPropsXY) => [];

--- a/src/charts/scatter.ts
+++ b/src/charts/scatter.ts
@@ -1,3 +1,140 @@
-import { Group } from "../components";
+import { scaleLinear, ScaleLinear } from "d3-scale";
+import { Datum, Group } from "../components";
+import { BAR, getPathData } from "../coords";
+import { MaxValue } from "../types";
+import { FONT_SIZE, getTextColor } from "../utils";
+import { getGroupLabelStrokeWidth, getRotate, STROKE_WIDTH } from "./utils";
 
-export const getScatterGetters = (props: Group.GetterPropsXY) => [];
+export const getScatterGetters = ({
+  groups,
+  maxValue,
+  shareDomain,
+  cartoonize,
+  colorMap,
+  showDatumLabels,
+  textDims,
+  dims: { width, height, margin, BASE_MARGIN },
+}: Group.GetterPropsXY) => {
+  const { xScale, yScale } = getScales({ maxValue, width, height });
+  const groupsGetters: Group.Getter[] = [];
+
+  for (const group of groups) {
+    const { key } = group;
+    const groupGetters: Group.Getter = {
+      key,
+      g: ({ s, _g }) => {
+        const d = BAR;
+        const x = margin.left + width * 0.5;
+        const y = margin.top + height * 0.5;
+        const labelX = 0;
+        const labelY = BASE_MARGIN;
+        const labelFontSize = s(0, shareDomain ? FONT_SIZE.groupLabel : 0);
+        const labelStrokeWidth = getGroupLabelStrokeWidth(labelFontSize);
+        const opacity = group.opacity ?? 1;
+
+        return {
+          d,
+          x: s(x, null, _g?.x),
+          y: s(y, null, _g?.y),
+          labelX,
+          labelY,
+          labelFontSize,
+          labelStrokeWidth,
+          opacity,
+        };
+      },
+      data: [],
+    };
+
+    for (const datum of group.data) {
+      const { key, x, y, fill } = datum;
+      const value = 0;
+
+      const datumX = xScale(x);
+      const datumY = yScale(y);
+      const datumFill = fill ?? colorMap.get(key, group.key, shareDomain);
+
+      const datumGetters: Datum.Getter = {
+        key,
+        teleportKey: `${group.key}:${key}`,
+        teleportFrom: datum.teleportFrom,
+        value,
+        g: ({ s, _g }) => {
+          const d = s(
+            BAR,
+            getPathData({
+              type: "bubble",
+              r: 4,
+              cartoonize,
+            })
+          );
+          const clipPath = getPathData({
+            type: "bar",
+            width,
+            height,
+            cartoonize,
+          });
+          const x = s(0, datumX - width * 0.5);
+          const y = s(0, datumY - height * 0.5);
+          const rotate = getRotate(_g?.rotate);
+          const strokeWidth = s(0, STROKE_WIDTH);
+          const labelX = 0;
+          const labelY = 0;
+          const labelFontSize = showDatumLabels ? FONT_SIZE.datumLabel : 0;
+          const labelFill = getTextColor(datumFill);
+          const valueX = 0;
+          const valueY = 0;
+          const valueFontSize = 0;
+          const valueFill = "black";
+          const opacity = datum.opacity ?? 1;
+
+          return {
+            d,
+            clipPath,
+            x,
+            y,
+            rotate,
+            fill: datumFill,
+            strokeWidth,
+            labelX,
+            labelY,
+            labelFontSize,
+            labelFill,
+            valueX,
+            valueY,
+            valueFontSize,
+            valueFill,
+            opacity,
+          };
+        },
+      };
+
+      groupGetters.data.push(datumGetters);
+    }
+
+    groupsGetters.push(groupGetters);
+  }
+
+  return groupsGetters;
+};
+
+const getScales = ({
+  maxValue,
+  width,
+  height,
+}: {
+  maxValue: MaxValue;
+  width: number;
+  height: number;
+}): {
+  xScale: ScaleLinear<number, number>;
+  yScale: ScaleLinear<number, number>;
+} => {
+  const xScale = scaleLinear().domain([0, maxValue.actual]).range([0, width]);
+  const yScale = scaleLinear().domain([0, maxValue.actual]).range([height, 0]);
+
+  return {
+    xScale,
+    yScale,
+  };
+};

--- a/src/charts/scatter.ts
+++ b/src/charts/scatter.ts
@@ -1,20 +1,20 @@
 import { scaleLinear, ScaleLinear } from "d3-scale";
 import { Datum, Group } from "../components";
 import { BAR, getPathData } from "../coords";
-import { MaxValue } from "../types";
+import { Max } from "../types";
 import { FONT_SIZE, getTextColor } from "../utils";
 import { getGroupLabelStrokeWidth, getRotate, STROKE_WIDTH } from "./utils";
 
 export const getScatterGetters = ({
   groups,
-  maxValue,
+  maxValue: { x: xMaxValue, y: yMaxValue },
   shareDomain,
   cartoonize,
   colorMap,
   showDatumLabels,
   dims: { width, height, margin, BASE_MARGIN },
 }: Group.GetterPropsXY) => {
-  const { xScale, yScale } = getScales({ maxValue, width, height });
+  const { xScale, yScale } = getScales({ xMaxValue, yMaxValue, width, height });
   const groupsGetters: Group.Getter[] = [];
 
   for (const group of groups) {
@@ -119,19 +119,21 @@ export const getScatterGetters = ({
 };
 
 const getScales = ({
-  maxValue,
+  xMaxValue,
+  yMaxValue,
   width,
   height,
 }: {
-  maxValue: MaxValue;
+  xMaxValue: Max;
+  yMaxValue: Max;
   width: number;
   height: number;
 }): {
   xScale: ScaleLinear<number, number>;
   yScale: ScaleLinear<number, number>;
 } => {
-  const xScale = scaleLinear().domain([0, maxValue.actual]).range([0, width]);
-  const yScale = scaleLinear().domain([0, maxValue.actual]).range([height, 0]);
+  const xScale = scaleLinear().domain([0, xMaxValue.actual]).range([0, width]);
+  const yScale = scaleLinear().domain([0, yMaxValue.actual]).range([height, 0]);
 
   return {
     xScale,

--- a/src/charts/scatter.ts
+++ b/src/charts/scatter.ts
@@ -27,7 +27,7 @@ export const getScatterGetters = ({
         const y = margin.top + height * 0.5;
         const labelX = 0;
         const labelY = BASE_MARGIN;
-        const labelFontSize = s(0, shareDomain ? FONT_SIZE.groupLabel : 0);
+        const labelFontSize = 0;
         const labelStrokeWidth = getGroupLabelStrokeWidth(labelFontSize);
         const opacity = group.opacity ?? 1;
 

--- a/src/charts/treemap.ts
+++ b/src/charts/treemap.ts
@@ -82,6 +82,7 @@ export const getTreemapGetters = ({
 
       const datumGetters: Datum.Getter = {
         key,
+        type: "value",
         teleportKey: `${group.data.key}:${key}`,
         teleportFrom: datum.data.teleportFrom,
         value,

--- a/src/charts/treemap.ts
+++ b/src/charts/treemap.ts
@@ -16,7 +16,7 @@ const PADDING = 2;
 export const getTreemapGetters = ({
   groups,
   shareDomain,
-  maxValue,
+  maxValue: { value: maxValue },
   showValues,
   showDatumLabels,
   svg,

--- a/src/charts/treemap.ts
+++ b/src/charts/treemap.ts
@@ -1,7 +1,7 @@
 import { hierarchy, treemap, treemapResquarify } from "d3-hierarchy";
 import { Datum, Group } from "../components";
 import { BAR, getPathData } from "../coords";
-import { InputGroup } from "../types";
+import { InputGroupValue } from "../types";
 import { FONT_SIZE, getTextColor } from "../utils";
 import { TreemapHierarchyRoot } from "./types";
 import {
@@ -24,7 +24,7 @@ export const getTreemapGetters = ({
   textDims,
   colorMap,
   cartoonize,
-}: Group.GetterProps): Group.Getter[] => {
+}: Group.GetterPropsValue): Group.Getter[] => {
   const root = getRoot({
     groups,
     width: maxValue.k * width,
@@ -148,7 +148,7 @@ const getRoot = ({
   width,
   height,
 }: {
-  groups: InputGroup[];
+  groups: InputGroupValue[];
   width: number;
   height: number;
 }): TreemapHierarchyRoot => {

--- a/src/charts/types.ts
+++ b/src/charts/types.ts
@@ -1,4 +1,4 @@
-import { InputDatum, InputGroup } from "../types";
+import { InputDatumValue, InputGroupValue } from "../types";
 
 type Root<T> = {
   r: number;
@@ -9,8 +9,8 @@ type Root<T> = {
 };
 
 export type HierarchyRoot = {
-  children?: (Root<InputGroup> & {
-    children?: Root<InputDatum>[];
+  children?: (Root<InputGroupValue> & {
+    children?: Root<InputDatumValue>[];
   })[];
 };
 
@@ -24,7 +24,7 @@ type TreemapRoot<T> = {
 };
 
 export type TreemapHierarchyRoot = {
-  children?: (TreemapRoot<InputGroup> & {
-    children?: TreemapRoot<InputDatum>[];
+  children?: (TreemapRoot<InputGroupValue> & {
+    children?: TreemapRoot<InputDatumValue>[];
   })[];
 };

--- a/src/charts/utils.ts
+++ b/src/charts/utils.ts
@@ -5,7 +5,7 @@ export const TEXT_MARGIN = 8;
 
 export const PADDING = 4;
 
-export const STROKE_WIDTH = 2;
+export const STROKE_WIDTH = 1;
 
 export const getRotate = (_rotate = 0, cartoonize?: boolean): number => {
   const rotate = _rotate <= -90 ? -180 : _rotate <= 90 ? 0 : 180;

--- a/src/components/Axis.ts
+++ b/src/components/Axis.ts
@@ -1,7 +1,7 @@
 import { scaleLinear } from "d3-scale";
 import { Text } from ".";
 import { Dimensions, Margin, ResolvedDimensions } from "../dims";
-import { AxisType } from "../types";
+import { AxisType, MaxValue, MaxXY } from "../types";
 import { max } from "../utils";
 import * as Tick from "./AxisTick";
 import * as Generic from "./Generic";
@@ -208,4 +208,21 @@ export const getWidth = ({
   });
 
   return max(ticksWidths) as number;
+};
+
+export const getMaxValue = ({
+  type,
+  maxValue,
+}: {
+  type: AxisType;
+  maxValue: MaxValue | MaxXY;
+}): number => {
+  switch (type) {
+    case "horizontal":
+      return maxValue.type === "value" ? 0 : maxValue.x.actual;
+    case "vertical":
+      return maxValue.type === "value"
+        ? maxValue.value.actual
+        : maxValue.y.actual;
+  }
 };

--- a/src/components/Axis.ts
+++ b/src/components/Axis.ts
@@ -1,10 +1,11 @@
 import { scaleLinear } from "d3-scale";
 import { Text } from ".";
-import { Margin, ResolvedDimensions } from "../dims";
+import { Dimensions, Margin, ResolvedDimensions } from "../dims";
+import { AxisType } from "../types";
 import { max } from "../utils";
+import * as Tick from "./AxisTick";
 import * as Generic from "./Generic";
 import { Svg, SVGSelection } from "./Svg";
-import * as Tick from "./Tick";
 
 type G = {
   x: number;
@@ -18,6 +19,7 @@ export type Getter = Generic.Getter<
 >;
 
 export const getters = ({
+  type,
   title,
   titleMargin,
   svg,
@@ -26,6 +28,7 @@ export const getters = ({
   maxValue,
   _maxValue,
 }: {
+  type: AxisType;
   title: string;
   titleMargin: Margin;
   svg: Svg;
@@ -37,24 +40,36 @@ export const getters = ({
   const ticks = scaleLinear().domain([0, maxValue]).ticks(5);
 
   return {
-    key: "verticalAxis",
+    key: `${type}-axis`,
     g: ({ s, _g }) => {
+      const x = dims.margin.left;
+      let y: number;
+      switch (type) {
+        case "vertical":
+          y = dims.margin.top;
+          break;
+        case "horizontal":
+          y = dims.fullHeight - dims.margin.bottom;
+          break;
+      }
+
       return {
-        x: s(dims.margin.left, null, _g?.x),
-        y: s(dims.margin.top, null, _g?.y),
+        x: s(x, null, _g?.x),
+        y: s(y, null, _g?.y),
         opacity: s(0, 1),
       };
     },
     title: title
       ? Text.getter({
           text: title,
-          textType: "verticalAxisTitle",
-          anchor: "start",
+          type: "axisTitle",
+          anchor: type === "vertical" ? "start" : "end",
           svg,
           dims: { ...dims, margin: titleMargin },
         })
       : undefined,
     ticks: Tick.getters({
+      axisType: type,
       ticks,
       maxValue,
       _maxValue,
@@ -76,8 +91,9 @@ export const ints = ({
     _getters,
     _ints,
     modifyInt: ({ getter, int, _updateInt }) => {
-      const _titleGetter = _getters?.find((d) => d.key === getter.key)?.title;
-      const _tickGetters = _getters?.find((d) => d.key === getter.key)?.ticks;
+      const _getter = _getters?.find((d) => d.key === getter.key);
+      const _titleGetter = _getter?.title;
+      const _tickGetters = _getter?.ticks;
 
       return {
         ...int,
@@ -118,18 +134,20 @@ export const resolve = ({ ints, t }: { ints: Int[]; t: number }) => {
 export const render = ({
   resolved,
   selection,
+  type,
 }: {
   resolved: Resolved[];
   selection: SVGSelection;
+  type: AxisType;
 }) => {
   const titles = resolved.flatMap((d) => d.titles);
   const ticks = resolved.flatMap((d) => d.ticks);
 
   const verticalAxisSelection = selection
-    .selectAll<SVGGElement, Resolved>(".vertical-axis")
+    .selectAll<SVGGElement, Resolved>(`.${type}-axis`)
     .data(resolved)
     .join("g")
-    .attr("class", "vertical-axis")
+    .attr("class", `${type}-axis`)
     .attr("transform", (d) => `translate(${d.x}, ${d.y})`)
     .style("opacity", (d) => d.opacity)
     // Vertical axis needs to be the first element in SVG, so it doesn't overlap bars.
@@ -137,13 +155,47 @@ export const render = ({
 
   Text.render({
     resolved: titles,
-    key: "verticalAxisTitle",
+    key: "title",
     selection: verticalAxisSelection,
   });
   Tick.render({
     resolved: ticks,
     selection: verticalAxisSelection,
+    axisType: type,
   });
+};
+
+export const updateDims = ({
+  type,
+  dims,
+  svg,
+  maxValue,
+  titleHeight,
+  tickHeight,
+}: {
+  type: AxisType;
+  dims: Dimensions;
+  svg: Svg;
+  maxValue: number;
+  titleHeight: number;
+  tickHeight: number;
+}): void => {
+  const width = getWidth({ svg, maxValue });
+
+  switch (type) {
+    case "horizontal":
+      dims
+        .addRight(width * 0.5)
+        .addBottom(titleHeight)
+        .addBottom(tickHeight + Tick.SIZE + Tick.LABEL_MARGIN);
+      break;
+    case "vertical":
+      dims
+        .addLeft(width + Tick.SIZE + Tick.LABEL_MARGIN)
+        .addTop(dims.BASE_MARGIN)
+        .addTop(titleHeight);
+      break;
+  }
 };
 
 export const getWidth = ({
@@ -155,8 +207,8 @@ export const getWidth = ({
 }): number => {
   const ticks = scaleLinear().domain([0, maxValue]).nice().ticks(5);
   const ticksWidths = ticks.map((d) => {
-    return svg.measureText(d, "tick").width;
+    return svg.measureText(d, "axisTick").width;
   });
 
-  return (max(ticksWidths) as number) + Tick.WIDTH;
+  return max(ticksWidths) as number;
 };

--- a/src/components/Axis.ts
+++ b/src/components/Axis.ts
@@ -190,10 +190,7 @@ export const updateDims = ({
         .addBottom(tickHeight + Tick.SIZE + Tick.LABEL_MARGIN);
       break;
     case "vertical":
-      dims
-        .addLeft(width + Tick.SIZE + Tick.LABEL_MARGIN)
-        .addTop(dims.BASE_MARGIN)
-        .addTop(titleHeight);
+      dims.addLeft(width + Tick.SIZE + Tick.LABEL_MARGIN).addTop(titleHeight);
       break;
   }
 };

--- a/src/components/AxisTick.ts
+++ b/src/components/AxisTick.ts
@@ -2,17 +2,19 @@ import { scaleLinear } from "d3-scale";
 import { Selection } from "d3-selection";
 import { HALF_FONT_K } from "../charts/utils";
 import { ResolvedDimensions } from "../dims";
+import { AxisType } from "../types";
 import { FONT_SIZE, FONT_WEIGHT } from "../utils";
+import * as Axis from "./Axis";
 import * as Generic from "./Generic";
-import * as VerticalAxis from "./VerticalAxis";
 
-export const WIDTH = 12;
+export const SIZE = 5;
+export const LABEL_MARGIN = 3;
 
 type G = {
   x: number;
   y: number;
-  width: number;
-  height: number;
+  size: number;
+  tickLabelHeight: number;
   fontSize: number;
   opacity: number;
 };
@@ -20,42 +22,47 @@ type G = {
 export type Getter = Generic.Getter<G>;
 
 export const getters = ({
+  axisType,
   ticks,
   maxValue,
   _maxValue,
   dims: { width, height },
   tickHeight,
 }: {
+  axisType: AxisType;
   ticks: number[];
   maxValue: number;
   _maxValue: number | undefined;
   dims: ResolvedDimensions;
   tickHeight: number;
 }): Getter[] => {
-  const yScale = scaleLinear().domain([maxValue, 0]).range([0, height]);
-  let _yScale: (tick: number) => number = () => height;
+  const isVerticalAxis = axisType === "vertical";
+  const size = isVerticalAxis ? height : width;
+  let _scale: (tick: number) => number = () => (isVerticalAxis ? size : 0);
 
   if (_maxValue !== undefined) {
-    _yScale = scaleLinear().domain([_maxValue, 0]).range([0, height]);
+    const _scaleDomain = isVerticalAxis ? [_maxValue, 0] : [0, _maxValue];
+    _scale = scaleLinear().domain(_scaleDomain).range([0, size]);
   }
 
   return ticks.map((tick) => {
     const getters: Getter = {
       key: `${tick}`,
       g: ({ s }) => {
-        const x = -WIDTH;
+        const x = 0;
+        const _y = _scale(tick);
         const y = s(
-          _yScale(tick),
-          (1 - tick / maxValue) * height,
-          yScale(tick)
+          _y,
+          (isVerticalAxis ? 1 - tick / maxValue : tick / maxValue) * size,
+          _y
         );
 
         return {
-          x,
-          y,
-          width,
-          height: tickHeight,
-          fontSize: FONT_SIZE.tick,
+          x: isVerticalAxis ? x : y,
+          y: isVerticalAxis ? y : x,
+          size: isVerticalAxis ? width : height,
+          tickLabelHeight: tickHeight,
+          fontSize: FONT_SIZE.axisTick,
           opacity: s(0, 1),
         };
       },
@@ -76,15 +83,14 @@ export const resolve = Generic.resolve<G, Resolved, Int>();
 export const render = ({
   selection,
   resolved,
+  axisType,
 }: {
-  selection: Selection<
-    SVGGElement,
-    VerticalAxis.Resolved,
-    SVGSVGElement,
-    unknown
-  >;
+  selection: Selection<SVGGElement, Axis.Resolved, SVGSVGElement, unknown>;
   resolved: Resolved[];
+  axisType: AxisType;
 }): void => {
+  const isVerticalAxis = axisType === "vertical";
+
   selection
     .selectAll<SVGGElement, Resolved>(".tick")
     .data(resolved, (d) => d.key)
@@ -98,11 +104,19 @@ export const render = ({
         .data((d) => [d])
         .join("text")
         .attr("class", "label")
-        .attr("transform", `translate(-2, 0)`)
-        .attr("dy", (d) => -d.height * HALF_FONT_K)
-        .style("text-anchor", "end")
+        .attr(
+          "transform",
+          isVerticalAxis
+            ? `translate(-${SIZE + LABEL_MARGIN}, 0)`
+            : `translate(0, ${LABEL_MARGIN})`
+        )
+        .attr(
+          "dy",
+          (d) => (isVerticalAxis ? -1 : 1) * d.tickLabelHeight * HALF_FONT_K
+        )
+        .style("text-anchor", isVerticalAxis ? "end" : "middle")
         .style("font-size", (d) => d.fontSize)
-        .style("font-weight", FONT_WEIGHT.tick)
+        .style("font-weight", FONT_WEIGHT.axisTick)
         .style("dominant-baseline", "hanging")
         .text((d) => d.key)
     )
@@ -112,8 +126,8 @@ export const render = ({
         .data((d) => [d])
         .join("line")
         .attr("class", "bold-line")
-        .attr("x1", 2)
-        .attr("x2", 7)
+        .attr(isVerticalAxis ? "x1" : "y1", isVerticalAxis ? -SIZE : 0)
+        .attr(isVerticalAxis ? "x2" : "y2", isVerticalAxis ? 0 : SIZE)
         .style("stroke", "#696969")
     )
     .call((g) =>
@@ -122,8 +136,10 @@ export const render = ({
         .data((d) => [d])
         .join("line")
         .attr("class", "light-line")
-        .attr("x1", 7)
-        .attr("x2", (d) => d.width)
+        .attr(isVerticalAxis ? "x1" : "y1", 0)
+        .attr(isVerticalAxis ? "x2" : "y2", (d) =>
+          isVerticalAxis ? d.size : -d.size
+        )
         .style("stroke", "#ededed")
     );
 };

--- a/src/components/AxisTick.ts
+++ b/src/components/AxisTick.ts
@@ -38,6 +38,8 @@ export const getters = ({
 }): Getter[] => {
   const isVerticalAxis = axisType === "vertical";
   const size = isVerticalAxis ? height : width;
+  const scaleDomain = isVerticalAxis ? [maxValue, 0] : [0, maxValue];
+  const scale = scaleLinear().domain(scaleDomain).range([0, size]);
   let _scale: (tick: number) => number = () => (isVerticalAxis ? size : 0);
 
   if (_maxValue !== undefined) {
@@ -50,11 +52,10 @@ export const getters = ({
       key: `${tick}`,
       g: ({ s }) => {
         const x = 0;
-        const _y = _scale(tick);
         const y = s(
-          _y,
+          _scale(tick),
           (isVerticalAxis ? 1 - tick / maxValue : tick / maxValue) * size,
-          _y
+          scale(tick)
         );
 
         return {

--- a/src/components/ColorLegend.ts
+++ b/src/components/ColorLegend.ts
@@ -1,6 +1,6 @@
 import { ColorMap } from "../colors";
-import { ResolvedDimensions } from "../dims";
-import { Anchor } from "../types";
+import { Dimensions, ResolvedDimensions } from "../dims";
+import { Anchor, ChartType } from "../types";
 import { FONT_SIZE, FONT_WEIGHT, max } from "../utils";
 import * as Generic from "./Generic";
 import { Svg, SVGSelection } from "./Svg";
@@ -239,8 +239,27 @@ export const render = ({
     );
 };
 
-// --- UTILS
+export const updateDims = ({
+  dims,
+  getters,
+  itemHeight,
+  chartType,
+}: {
+  dims: Dimensions;
+  getters: Getter[] | undefined;
+  itemHeight: number;
+  chartType: ChartType;
+}): void => {
+  if (getters) {
+    const rows = max(getters.map((d) => d.rowIndex)) ?? -1;
+    const height = (rows + 1) * itemHeight;
+    dims.addBottom(height).addBottom(dims.BASE_MARGIN);
+  }
 
-export const getHeight = (getters: Getter[], itemHeight: number): number => {
-  return ((max(getters.map((d) => d.rowIndex)) ?? -1) + 1) * itemHeight;
+  // Account for bar chart's bottom labels.
+  if (chartType === "bar") {
+    dims.addBottom(dims.BASE_MARGIN);
+  }
+
+  dims.addBottom(dims.BASE_MARGIN);
 };

--- a/src/components/Group.ts
+++ b/src/components/Group.ts
@@ -227,10 +227,22 @@ export const render = ({
     dataSelection
       .on("mouseover mousemove", function (e: MouseEvent, d) {
         tooltip.move(e.clientX, e.clientY);
-        tooltip.setText({
-          label: d.key,
-          value: d.value,
-        });
+
+        switch (d.type) {
+          case "value":
+            tooltip.setText({
+              label: d.key,
+              value: d.value,
+            });
+            break;
+          case "xy":
+            tooltip.setText({
+              label: d.key,
+              value: `(${d.xValue}, ${d.yValue})`,
+            });
+            break;
+        }
+
         tooltip.show();
       })
       .on("mouseout", function () {

--- a/src/components/Group.ts
+++ b/src/components/Group.ts
@@ -1,13 +1,15 @@
 import { getBarGetters } from "../charts/bar";
 import { getBubbleGetters } from "../charts/bubble";
 import { getPieGetters } from "../charts/pie";
+import { getScatterGetters } from "../charts/scatter";
 import { getTreemapGetters } from "../charts/treemap";
 import { ColorMap } from "../colors";
 import { ResolvedDimensions } from "../dims";
 import {
   BarChartSubtype,
   ChartType,
-  InputGroup,
+  InputGroupValue,
+  InputGroupXY,
   MaxValue,
   TextDims,
 } from "../types";
@@ -30,9 +32,8 @@ type G = {
 
 export type Getter = Generic.Getter<G, { data: Datum.Getter[] }>;
 
-export type GetterProps = {
+type BaseGetterProps = {
   // Data.
-  groups: InputGroup[];
   groupsKeys: string[];
   dataKeys: string[];
   // Scales.
@@ -50,21 +51,46 @@ export type GetterProps = {
   cartoonize: boolean;
 };
 
-export const getters = (
-  chartType: ChartType,
-  chartSubtype: BarChartSubtype | undefined,
-  props: GetterProps
+export type GetterPropsValue = BaseGetterProps & {
+  groups: InputGroupValue[];
+};
+
+export type GetterPropsXY = BaseGetterProps & {
+  groups: InputGroupXY[];
+};
+
+export const valueGetters = (
+  props:
+    | {
+        chartType: "bar";
+        chartSubtype: BarChartSubtype;
+        props: GetterPropsValue;
+      }
+    | {
+        chartType: Exclude<ChartType, "bar" | "scatter">;
+        props: GetterPropsValue;
+      }
 ): Getter[] => {
-  switch (chartType) {
+  switch (props.chartType) {
     case "bar":
-      return getBarGetters(chartSubtype as BarChartSubtype, props);
+      return getBarGetters(props.chartSubtype, props.props);
     case "bubble":
-      return getBubbleGetters(props);
+      return getBubbleGetters(props.props);
     case "pie":
-      return getPieGetters(props);
+      return getPieGetters(props.props);
     case "treemap":
-      return getTreemapGetters(props);
+      return getTreemapGetters(props.props);
   }
+};
+
+export const xyGetters = ({
+  chartType,
+  props,
+}: {
+  chartType: "scatter";
+  props: GetterPropsXY;
+}): Getter[] => {
+  return getScatterGetters(props);
 };
 
 export type Int = Generic.Int<G, { data: Datum.Int[] }>;

--- a/src/components/Group.ts
+++ b/src/components/Group.ts
@@ -11,6 +11,7 @@ import {
   InputGroupValue,
   InputGroupXY,
   MaxValue,
+  MaxXY,
   TextDims,
 } from "../types";
 import { FONT_WEIGHT, stateOrderComparator } from "../utils";
@@ -38,7 +39,6 @@ type BaseGetterProps = {
   dataKeys: string[];
   // Scales.
   shareDomain: boolean;
-  maxValue: MaxValue;
   // Labels.
   showValues: boolean;
   showDatumLabels: boolean;
@@ -53,10 +53,12 @@ type BaseGetterProps = {
 
 export type GetterPropsValue = BaseGetterProps & {
   groups: InputGroupValue[];
+  maxValue: MaxValue;
 };
 
 export type GetterPropsXY = BaseGetterProps & {
   groups: InputGroupXY[];
+  maxValue: MaxXY;
 };
 
 export const valueGetters = (

--- a/src/components/Step.ts
+++ b/src/components/Step.ts
@@ -15,10 +15,6 @@ export type Getter = {
   horizontalAxis: Axis.Getter | undefined;
 };
 
-// one-dimensional (value) - bar, bubble, pie, treemap
-// two-dimensional (x, y) - scatter
-// three-dimensional (x, y, value) - bubble
-
 export const getters = ({
   steps: inputSteps,
   svg,
@@ -141,7 +137,7 @@ export const getters = ({
     }
 
     if (title || subtitle) {
-      dims.addTop(dims.BASE_MARGIN);
+      dims.addTop(dims.BASE_MARGIN * 2);
     }
 
     const colorMap = new ColorMap(domain, paletteName);

--- a/src/components/Text.spec.ts
+++ b/src/components/Text.spec.ts
@@ -7,7 +7,7 @@ describe("Text", () => {
   const enterGetter = Text.getter({
     svg,
     text: "Hello, Plotteus!",
-    textType: "title",
+    type: "title",
     anchor: "middle",
     dims: dims.resolve(),
   });
@@ -91,7 +91,7 @@ describe("Text", () => {
   const updateGetter = Text.getter({
     svg,
     text: "Hello, Plotteus!",
-    textType: "datumLabel",
+    type: "datumLabel",
     anchor: "start",
     dims: dims.resolve(),
   });

--- a/src/components/Text.ts
+++ b/src/components/Text.ts
@@ -1,5 +1,5 @@
 import { Selection } from "d3-selection";
-import { ResolvedDimensions } from "../dims";
+import { Dimensions, ResolvedDimensions } from "../dims";
 import { Anchor, TextType } from "../types";
 import { FONT_SIZE, FONT_WEIGHT } from "../utils";
 import * as Generic from "./Generic";
@@ -17,18 +17,18 @@ export type Getter = Generic.Getter<G>;
 
 export const getter = ({
   text,
-  textType,
+  type,
   anchor,
   svg,
   dims: { fullWidth, margin },
 }: {
   text: string;
-  textType: TextType;
+  type: TextType;
   anchor: Anchor;
   svg: Svg;
   dims: ResolvedDimensions;
 }): Getter => {
-  const { width: textWidth } = svg.measureText(text, textType);
+  const { width: textWidth } = svg.measureText(text, type);
 
   return {
     key: text,
@@ -49,8 +49,8 @@ export const getter = ({
       return {
         x: s(x, null, _g?.x),
         y: s(margin.top, null, _g?.y),
-        fontSize: FONT_SIZE[textType],
-        fontWeight: FONT_WEIGHT[textType],
+        fontSize: FONT_SIZE[type],
+        fontWeight: FONT_WEIGHT[type],
         opacity: s(0, 1),
       };
     },
@@ -87,4 +87,19 @@ export const render = ({
     .style("dominant-baseline", "hanging")
     .style("opacity", (d) => d.opacity)
     .text((d) => d.key);
+};
+
+export const updateDims = ({
+  dims,
+  svg,
+  textType,
+  text,
+}: {
+  dims: Dimensions;
+  svg: Svg;
+  textType: TextType;
+  text: string;
+}): void => {
+  const { height } = svg.measureText(text, textType);
+  dims.addTop(height);
 };

--- a/src/components/Tooltip.ts
+++ b/src/components/Tooltip.ts
@@ -44,7 +44,7 @@ export const makeTooltip = (div: HTMLDivElement) => {
     value,
   }: {
     label: string;
-    value: number;
+    value: number | string;
   }): void => {
     datumLabel.text(label ? `${label}:` : "");
     valueLabel.text(` ${value}`);

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,9 +1,9 @@
+export * as Axis from "./Axis";
+export * as AxisTick from "./AxisTick";
 export * as ColorLegend from "./ColorLegend";
 export * as Datum from "./Datum";
 export * as Group from "./Group";
 export * as Step from "./Step";
 export * from "./Svg";
 export * as Text from "./Text";
-export * as Tick from "./Tick";
 export * from "./Tooltip";
-export * as VerticalAxis from "./VerticalAxis";

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -44,6 +44,7 @@ export const shouldShareDomain = (type: ChartType): boolean => {
     case "pie":
       return true;
     case "bubble":
+    case "scatter":
     case "treemap":
       return false;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,6 @@ type BaseInputStep = {
 
   /** Values & data labels. */
   showValues?: boolean;
-  maxValue?: number;
   showDatumLabels?: boolean;
 
   /** Appearance. */
@@ -31,6 +30,9 @@ export type InputStep = BaseInputStep &
     | {
         chartType: "bar";
         chartSubtype?: BarChartSubtype;
+        valueScale?: {
+          maxValue?: number;
+        };
         verticalAxis?: {
           show?: boolean;
           title?: string;
@@ -39,6 +41,12 @@ export type InputStep = BaseInputStep &
       }
     | {
         chartType: "scatter";
+        xScale?: {
+          maxValue?: number;
+        };
+        yScale?: {
+          maxValue?: number;
+        };
         horizontalAxis?: {
           show?: boolean;
           title?: string;
@@ -51,6 +59,9 @@ export type InputStep = BaseInputStep &
       }
     | {
         chartType: Exclude<ChartType, "bar" | "scatter">;
+        valueScale?: {
+          maxValue?: number;
+        };
         groups: InputGroupValue[];
       }
   );
@@ -111,7 +122,18 @@ export type TextDims = {
   };
 };
 
-export type MaxValue = {
+export type DataMaxValue = {
+  type: "value";
+  value: number;
+};
+
+export type DataMaxXY = {
+  type: "xy";
+  x: number;
+  y: number;
+};
+
+export type Max = {
   data: number;
   scale: number | undefined;
   actual: number;
@@ -119,6 +141,17 @@ export type MaxValue = {
   k: number;
   // complement of k, 1 - k
   kc: number;
+};
+
+export type MaxValue = {
+  type: "value";
+  value: Max;
+};
+
+export type MaxXY = {
+  type: "xy";
+  x: Max;
+  y: Max;
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,9 +24,6 @@ type BaseInputStep = {
   /** Appearance. */
   palette?: PaletteName;
   cartoonize?: boolean;
-
-  /** Data. */
-  groups: InputGroup[];
 };
 
 export type InputStep = BaseInputStep &
@@ -38,44 +35,74 @@ export type InputStep = BaseInputStep &
           show?: boolean;
           title?: string;
         };
+        groups: InputGroupValue[];
       }
     | {
-        chartType: Exclude<ChartType, "bar">;
+        chartType: "scatter";
+        horizontalAxis?: {
+          show?: boolean;
+          title?: string;
+        };
+        verticalAxis?: {
+          show?: boolean;
+          title?: string;
+        };
+        groups: InputGroupXY[];
+      }
+    | {
+        chartType: Exclude<ChartType, "bar" | "scatter">;
+        groups: InputGroupValue[];
       }
   );
 
-export type InputGroup = {
+export type InputGroupValue = {
   key: string;
   opacity?: number;
-  data: InputDatum[];
+  data: InputDatumValue[];
 };
 
-export type InputDatum = {
+export type InputGroupXY = {
   key: string;
-  value: number;
+  opacity?: number;
+  data: InputDatumXY[];
+};
+
+type BaseInputDatum = {
+  key: string;
   // Used to teleport datum between groups. Formatted as "groupKey:datumKey".
   teleportFrom?: string;
   fill?: string;
   opacity?: number;
 };
 
+export type InputDatumValue = BaseInputDatum & {
+  value: number;
+};
+
+export type InputDatumXY = BaseInputDatum & {
+  x: number;
+  y: number;
+};
+
 export type Anchor = "start" | "middle" | "end";
 
 // Charts.
-export type ChartType = "bar" | "bubble" | "pie" | "treemap";
+export type ChartType = "bar" | "bubble" | "pie" | "scatter" | "treemap";
 
 export type BarChartSubtype = "grouped" | "stacked";
+
+export type AxisType = "vertical" | "horizontal";
 
 export type TextType =
   | "title"
   | "subtitle"
   | "legendTitle"
   | "legendItem"
-  | "verticalAxisTitle"
+  | "axisTitle"
+  | "axisTick"
   | "groupLabel"
   | "datumLabel"
-  | "datumValue"
-  | "tick";
+  | "datumValue";
 
 export type TextDims = {
   [type in TextType]: {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,16 +10,20 @@ export const max = (array: number[]): number | undefined => {
   return array.length === 0 ? undefined : Math.max(...array);
 };
 
+export const sum = (array: number[]): number => {
+  return array.reduce((acc, d) => acc + d, 0);
+};
+
 export const FONT_SIZE: Record<TextType, number> = {
   title: 24,
   subtitle: 14,
   legendTitle: 12,
   legendItem: 12,
-  verticalAxisTitle: 12,
+  axisTitle: 12,
+  axisTick: 11,
   groupLabel: 14,
   datumLabel: 11,
   datumValue: 11,
-  tick: 11,
 };
 
 export const FONT_WEIGHT: Record<TextType, number> = {
@@ -27,11 +31,11 @@ export const FONT_WEIGHT: Record<TextType, number> = {
   subtitle: 400,
   legendTitle: 700,
   legendItem: 400,
-  verticalAxisTitle: 400,
+  axisTitle: 400,
+  axisTick: 400,
   groupLabel: 400,
   datumLabel: 600,
   datumValue: 400,
-  tick: 400,
 };
 
 export const getTextDims = (svg: Svg): TextDims => {


### PR DESCRIPTION
- Add Scatter chart
- Add HorizontalAxis
- Change the way of specifying `maxValue` (`valueScale: { maxValue }, xScale: { maxValue }, yScale: { maxValue }` instead of `maxValue: number`)
- Introduce a concept of `Value` (bar, bubble, pie, treemap) vs `XY` (scatter) charts
- Improve handling of dimensions (`Text`, `ColorLegend` & `Axis` components now implement `updateDims` methods)
- Adjust Datum's path stroke width (from 2px to 1px)
- Fix some spacing issues for bar charts