### PR TITLE
fix: Double Tooltip append

### DIFF
--- a/src/components/Tooltip.ts
+++ b/src/components/Tooltip.ts
@@ -4,7 +4,9 @@ export type Tooltip = ReturnType<typeof makeTooltip>;
 
 export const makeTooltip = (div: HTMLDivElement) => {
   const root = select(div)
-    .append("div")
+    .selectAll(".tooltip")
+    .data([null])
+    .join("div")
     .attr("class", "tooltip")
     .style("position", "fixed")
     .style("top", 0)
@@ -18,12 +20,20 @@ export const makeTooltip = (div: HTMLDivElement) => {
     .style("box-shadow", "0px 0px 48px 0px rgba(0, 0, 0, 0.15)")
     .style("opacity", 0);
   const content = root
-    .append("div")
+    .selectAll(".content")
+    .data([null])
+    .join("div")
     .attr("class", "content")
     .style("overflow-wrap", "break-word");
-  const datumLabel = content.append("span").attr("class", "datum-label");
+  const datumLabel = content
+    .selectAll(".datum-label")
+    .data([null])
+    .join("span")
+    .attr("class", "datum-label");
   const valueLabel = content
-    .append("span")
+    .selectAll(".value-label")
+    .data([null])
+    .join("span")
     .attr("class", "value-label")
     .style("font-weight", "bold");
 


### PR DESCRIPTION
Use `join` pattern to prevent double `Tooltip` append.