### PR TITLE
fix: Datum teleportation jump when changing dimensions (Scatter)

### DIFF
--- a/src/charts/ScatterChart.ts
+++ b/src/charts/ScatterChart.ts
@@ -90,8 +90,8 @@ export const getters = (
       key,
       g: ({ s, _g }) => {
         const d = BAR;
-        const x = margin.left + width * 0.5;
-        const y = margin.top + height * 0.5;
+        const x = 0;
+        const y = 0;
         const labelX = 0;
         const labelY = BASE_MARGIN;
         const labelFontSize = 0;
@@ -141,8 +141,8 @@ export const getters = (
             height,
             cartoonize,
           });
-          const x = s(0, datumX - width * 0.5);
-          const y = s(0, datumY - height * 0.5);
+          const x = s(0, margin.left + datumX);
+          const y = s(0, margin.top + datumY);
           const rotate = getRotate(_g?.rotate);
           const strokeWidth = s(0, STROKE_WIDTH);
           const labelX = 0;

--- a/src/charts/ScatterChart.ts
+++ b/src/charts/ScatterChart.ts
@@ -36,13 +36,13 @@ export const info = (inputStep: ScatterInputStep): Info => {
     ...Chart.baseInfo(inputStep, shareDomain),
     type: "scatter",
     groups,
-    maxValue: getMaxXY(inputStep),
+    maxValue: getMaxValue(inputStep),
     verticalAxis: inputStep.verticalAxis,
     horizontalAxis: inputStep.horizontalAxis,
   };
 };
 
-const getMaxXY = (step: ScatterInputStep): MaxXY => {
+const getMaxValue = (step: ScatterInputStep): MaxXY => {
   const xValues = step.groups.flatMap((d) => d.data.map((d) => d.x));
   const xMax = max(xValues) ?? 0;
   const yValues = step.groups.flatMap((d) => d.data.map((d) => d.y));


### PR DESCRIPTION
- Circles no longer jump along the X or Y axis when datum teleportation is used when changing the dimensions of the chart